### PR TITLE
Add 'thiserror' to FlvSocketError for easy error::Error implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,7 @@ checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5587c8485fcb8a2a435bc7745d09a047ffde71afa5c8928f8fbe99b519a62c62"
+version = "0.1.2"
 dependencies = [
  "async-fs",
  "async-io",
@@ -306,6 +304,7 @@ dependencies = [
  "pin-project",
  "pin-utils",
  "rustls",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "webpki",
@@ -406,6 +405,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-utils",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -414,8 +414,6 @@ dependencies = [
 [[package]]
 name = "fluvio-test-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9e4cb09caa5ff039928399ef5aa99206fd1b9a59df208cf6d94e2764fe5ce0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -951,6 +949,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
     "crates/socket",
     "crates/service"
 ]
+
+[patch.crates-io]
+fluvio-future = { path = "../future-aio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,3 @@ members = [
     "crates/socket",
     "crates/service"
 ]
-
-[patch.crates-io]
-fluvio-future = {path = "../future-aio"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,3 @@ members = [
     "crates/socket",
     "crates/service"
 ]
-
-[patch.crates-io]
-fluvio-future = { path = "../future-aio" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ members = [
     "crates/socket",
     "crates/service"
 ]
+
+[patch.crates-io]
+fluvio-future = {path = "../future-aio"}

--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -26,9 +26,10 @@ async-net = "1.4.3"
 tokio = { version = "0.2.21", features = ["macros"] }
 tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
 async-trait = "0.1.21"
+thiserror = "1.0.20"
 
 # Fluvio dependencies
-fluvio-future = { version = "0.1.0", features = ["tls", "net", "zero_copy"] }
+fluvio-future = { version = "0.1.2", features = ["tls", "net", "zero_copy"] }
 fluvio-protocol = { version = "0.2.0", features = ["derive", "api", "codec", "store"] }
 
 

--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper using fluvio protocol"

--- a/crates/socket/src/error.rs
+++ b/crates/socket/src/error.rs
@@ -1,30 +1,17 @@
-use fluvio_future::zero_copy::SendFileError;
-use std::fmt;
 use std::io::Error as IoError;
+use thiserror::Error;
+use fluvio_future::zero_copy::SendFileError;
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum FlvSocketError {
-    IoError(IoError),
-    SendFileError(SendFileError),
-}
-
-impl From<IoError> for FlvSocketError {
-    fn from(error: IoError) -> Self {
-        FlvSocketError::IoError(error)
-    }
-}
-
-impl From<SendFileError> for FlvSocketError {
-    fn from(error: SendFileError) -> Self {
-        FlvSocketError::SendFileError(error)
-    }
-}
-
-impl fmt::Display for FlvSocketError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            FlvSocketError::IoError(err) => write!(f, "{}", err),
-            FlvSocketError::SendFileError(err) => write!(f, "{:#?}", err),
-        }
-    }
+    #[error("IO error: {source}")]
+    IoError {
+        #[from]
+        source: IoError,
+    },
+    #[error("Zero-copy IO error: {source}")]
+    SendFileError {
+        #[from]
+        source: SendFileError,
+    },
 }

--- a/crates/socket/src/error.rs
+++ b/crates/socket/src/error.rs
@@ -1,6 +1,6 @@
+use fluvio_future::zero_copy::SendFileError;
 use std::io::Error as IoError;
 use thiserror::Error;
-use fluvio_future::zero_copy::SendFileError;
 
 #[derive(Error, Debug)]
 pub enum FlvSocketError {

--- a/crates/socket/src/multiplexing.rs
+++ b/crates/socket/src/multiplexing.rs
@@ -157,10 +157,7 @@ where
         } else {
             error!("no more response. server has terminated connection");
             Err(FlvSocketError::IoError {
-                source: IoError::new(
-                    ErrorKind::UnexpectedEof,
-                    "server has terminated connection",
-                )
+                source: IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection"),
             })
         }
     }
@@ -240,10 +237,10 @@ where
             }
             None => {
                 return Err(FlvSocketError::IoError {
-                        source: IoError::new(
+                    source: IoError::new(
                         ErrorKind::BrokenPipe,
                         "invalid socket, try creating new one",
-                    )
+                    ),
                 })
             }
         }
@@ -378,18 +375,21 @@ impl MultiPlexingResponseDispatcher {
                                     "failed locking, abandoning sending to socket: {}",
                                     correlation_id
                                 ),
-                            )
+                            ),
                         }),
                     }
                 }
-                SharedSender::Queue(queue_sender) => queue_sender.send(msg).await.map_err(|_| {
-                    FlvSocketError::IoError {
-                        source: IoError::new(
-                            ErrorKind::BrokenPipe,
-                            format!("problem sending to queue socket: {}", correlation_id),
-                        )
-                    }
-                }),
+                SharedSender::Queue(queue_sender) => {
+                    queue_sender
+                        .send(msg)
+                        .await
+                        .map_err(|_| FlvSocketError::IoError {
+                            source: IoError::new(
+                                ErrorKind::BrokenPipe,
+                                format!("problem sending to queue socket: {}", correlation_id),
+                            ),
+                        })
+                }
             }
         } else {
             Err(FlvSocketError::IoError {
@@ -399,7 +399,7 @@ impl MultiPlexingResponseDispatcher {
                         "no socket receiver founded for {}, abandoning sending",
                         correlation_id
                     ),
-                )
+                ),
             })
         }
     }

--- a/crates/socket/src/multiplexing.rs
+++ b/crates/socket/src/multiplexing.rs
@@ -156,10 +156,7 @@ where
             Ok(response)
         } else {
             error!("no more response. server has terminated connection");
-            Err(IoError::new(
-                ErrorKind::UnexpectedEof,
-                "server has terminated connection"
-            ).into())
+            Err(IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection").into())
         }
     }
 
@@ -236,7 +233,8 @@ where
                 return Err(IoError::new(
                     ErrorKind::BrokenPipe,
                     "invalid socket, try creating new one",
-                ).into())
+                )
+                .into())
             }
         }
 
@@ -362,19 +360,18 @@ impl MultiPlexingResponseDispatcher {
                             format!(
                                 "failed locking, abandoning sending to socket: {}",
                                 correlation_id
-                            )
-                        ).into()),
+                            ),
+                        )
+                        .into()),
                     }
                 }
-                SharedSender::Queue(queue_sender) => {
-                    queue_sender
-                        .send(msg)
-                        .await
-                        .map_err(|_| IoError::new(
-                            ErrorKind::BrokenPipe,
-                            format!("problem sending to queue socket: {}", correlation_id),
-                        ).into())
-                }
+                SharedSender::Queue(queue_sender) => queue_sender.send(msg).await.map_err(|_| {
+                    IoError::new(
+                        ErrorKind::BrokenPipe,
+                        format!("problem sending to queue socket: {}", correlation_id),
+                    )
+                    .into()
+                }),
             }
         } else {
             Err(IoError::new(
@@ -383,7 +380,8 @@ impl MultiPlexingResponseDispatcher {
                     "no socket receiver founded for {}, abandoning sending",
                     correlation_id
                 ),
-            ).into())
+            )
+            .into())
         }
     }
 }

--- a/crates/socket/src/stream.rs
+++ b/crates/socket/src/stream.rs
@@ -93,7 +93,7 @@ where
         } else {
             error!("no more response. server has terminated connection");
             Err(FlvSocketError::IoError {
-                source: IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection")
+                source: IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection"),
             })
         }
     }

--- a/crates/socket/src/stream.rs
+++ b/crates/socket/src/stream.rs
@@ -92,9 +92,7 @@ where
             }
         } else {
             error!("no more response. server has terminated connection");
-            Err(FlvSocketError::IoError {
-                source: IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection"),
-            })
+            Err(IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection").into())
         }
     }
 

--- a/crates/socket/src/stream.rs
+++ b/crates/socket/src/stream.rs
@@ -85,17 +85,16 @@ where
                     trace!("receive response: {:#?}", &response);
                     Ok(response)
                 }
-                Err(err) => {
-                    error!("error receiving response: {:?}", err);
-                    Err(FlvSocketError::IoError(err))
+                Err(source) => {
+                    error!("error receiving response: {:?}", source);
+                    Err(FlvSocketError::IoError { source })
                 }
             }
         } else {
             error!("no more response. server has terminated connection");
-            Err(FlvSocketError::IoError(IoError::new(
-                ErrorKind::UnexpectedEof,
-                "server has terminated connection",
-            )))
+            Err(FlvSocketError::IoError {
+                source: IoError::new(ErrorKind::UnexpectedEof, "server has terminated connection")
+            })
         }
     }
 


### PR DESCRIPTION
This depends on the PR for `fluvio-future:0.1.2` to land and be published to crates.io. Until then this won't build properly.