### PR TITLE
Relax &mut self on SerialSocket to &self

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,8 @@ checksum = "5c85295147490b8fcf2ea3d104080a105a8b2c63f9c319e82c02d8e952388919"
 [[package]]
 name = "fluvio-future"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a6dc548919905c5ebc5ad51e9b078e1fde7a0cce3c4d08d143814204afd910"
 dependencies = [
  "async-fs",
  "async-io",
@@ -414,6 +416,8 @@ dependencies = [
 [[package]]
 name = "fluvio-test-derive"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc9e4cb09caa5ff039928399ef5aa99206fd1b9a59df208cf6d94e2764fe5ce0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper using fluvio protocol"

--- a/crates/socket/src/multiplexing.rs
+++ b/crates/socket/src/multiplexing.rs
@@ -496,7 +496,7 @@ mod tests {
         let socket = FlvSocket::connect(&addr).await.expect("connect");
         debug!("client: connected to test server and waiting...");
         sleep(Duration::from_millis(20)).await;
-        let mut multiplexer = MultiplexerSocket::new(socket);
+        let multiplexer = MultiplexerSocket::new(socket);
         let mut slow = multiplexer.create_serial_socket().await;
         let mut fast = multiplexer.create_serial_socket().await;
 

--- a/crates/socket/src/multiplexing.rs
+++ b/crates/socket/src/multiplexing.rs
@@ -78,7 +78,7 @@ where
 
     /// get next available correlation to use
     //  use lock to ensure update happens in orderly manner
-    async fn next_correlation_id(&mut self) -> i32 {
+    async fn next_correlation_id(&self) -> i32 {
         let mut guard = self.correlation_id_counter.lock().await;
         let current_value = *guard;
         // update to new
@@ -87,7 +87,7 @@ where
     }
 
     /// create socket to perform request and response
-    pub async fn create_serial_socket(&mut self) -> SerialSocket<S> {
+    pub async fn create_serial_socket(&self) -> SerialSocket<S> {
         let correlation_id = self.next_correlation_id().await;
         let bytes_lock: SharedMsg = (Arc::new(Mutex::new(None)), Arc::new(Event::new()));
 
@@ -103,7 +103,7 @@ where
 
     /// create stream response
     pub async fn create_stream<R>(
-        &mut self,
+        &self,
         mut req_msg: RequestMessage<R>,
         queue_len: usize,
     ) -> Result<AsyncResponse<R>, FlvSocketError>


### PR DESCRIPTION
While reviewing the node-client PR infinyon/fluvio-client-node#12, I noticed that the `.admin()` interface requires a `&mut self` to construct, whereas all of the other kinds of client objects (TopicProducer, PartitionConsumer) only require &self, which I thought was strange. I dug down and ended up here, where I saw that `next_correlation_id` was requiring `&mut self` to be given. However, since `correlation_id_counter` is an `Arc<Mutex<T>>`, the mutex locking already provides us with a mutable interface to the counter, so we can change `next_correlation_id` to take `&self` without any problem. This will allow us to make all of the upper-level consumers of SerialSocket to relax to shared references, which will make language bindings like the node-client much nicer.