### PR TITLE
use exclusive features to separate out tls and native tls types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-future"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb262f8e2f83adac923ec2ed4dc20b5478dade0012ee2d5f8ef5b344e26711c"
+checksum = "b9eac52925a38cf92788318aeef688303f07d2ae17d021e2a8cacf194839ced4"
 dependencies = [
  "async-fs",
  "async-io",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-service"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "event-listener",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-channel",
  "async-mutex",

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "fluvio-service"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP service wrapper over fluvio protocol"
 repository = "https://github.com/infinyon/fluvio-socket"
@@ -24,7 +24,7 @@ tokio = { version = "0.2.21", features = ["macros"] }
 # Fluvio dependencies
 futures-util = { version = "0.3.5" }
 fluvio-future = { version = "0.1.0" }
-fluvio-socket = { version = "0.2.0", default-features = false , path = "../socket" }
+fluvio-socket = { version = "0.3.0",  path = "../socket" }
 fluvio-protocol = { version = "0.2.0", features = ["derive", "api", "codec"] }
 
 

--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"
@@ -13,7 +13,6 @@ name = "fluvio_socket"
 path = "src/lib.rs"
 
 [features]
-default = ["tls"]
 tls = ["fluvio-future/tls"]
 native_tls = ["fluvio-future/native2_tls"]
 

--- a/crates/socket/src/multiplexing.rs
+++ b/crates/socket/src/multiplexing.rs
@@ -35,10 +35,10 @@ use crate::InnerFlvStream;
 #[allow(unused)]
 pub type DefaultMultiplexerSocket = MultiplexerSocket<TcpStream>;
 
-#[cfg(feature = "tls")]
+#[cfg(all(not(feature = "native_tls"), feature = "tls"))]
 pub type AllMultiplexerSocket = MultiplexerSocket<fluvio_future::tls::AllTcpStream>;
 
-#[cfg(feature = "native_tls")]
+#[cfg(all(not(feature = "tls"), feature = "native_tls"))]
 pub type AllMultiplexerSocket = MultiplexerSocket<fluvio_future::native_tls::AllTcpStream>;
 
 type SharedMsg = (Arc<Mutex<Option<BytesMut>>>, Arc<Event>);
@@ -189,10 +189,10 @@ impl<R: Request> Stream for AsyncResponse<R> {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(all(not(feature = "native_tls"), feature = "tls"))]
 pub type AllSerialSocket = SerialSocket<fluvio_future::tls::AllTcpStream>;
 
-#[cfg(feature = "native_tls")]
+#[cfg(all(not(feature = "tls"), feature = "native_tls"))]
 pub type AllSerialSocket = SerialSocket<fluvio_future::native_tls::AllTcpStream>;
 
 /// socket that can send request and response one at time,

--- a/crates/socket/src/socket.rs
+++ b/crates/socket/src/socket.rs
@@ -22,10 +22,10 @@ use crate::InnerFlvStream;
 
 pub type FlvSocket = InnerFlvSocket<TcpStream>;
 
-#[cfg(feature = "tls")]
+#[cfg(all(not(feature = "native_tls"), feature = "tls"))]
 pub type AllFlvSocket = InnerFlvSocket<fluvio_future::tls::AllTcpStream>;
 
-#[cfg(feature = "native_tls")]
+#[cfg(all(not(feature = "tls"), feature = "native_tls"))]
 pub type AllFlvSocket = InnerFlvSocket<fluvio_future::native_tls::AllTcpStream>;
 
 /// FlvSocket is high level socket that can send and receive fluvio protocol

--- a/crates/socket/src/stream.rs
+++ b/crates/socket/src/stream.rs
@@ -19,11 +19,11 @@ use crate::FlvSocketError;
 pub type FlvStream = InnerFlvStream<TcpStream>;
 
 #[allow(unused)]
-#[cfg(feature = "tls")]
+#[cfg(all(not(feature = "native_tls"), feature = "tls"))]
 pub type AllFlvStream = InnerFlvStream<fluvio_future::tls::AllTcpStream>;
 
 #[allow(unused)]
-#[cfg(feature = "native_tls")]
+#[cfg(all(not(feature = "tls"), feature = "native_tls"))]
 pub type AllFlvStream = InnerFlvStream<fluvio_future::native_tls::AllTcpStream>;
 
 type FrameStream<S> = SplitStream<Framed<Compat<S>, FluvioCodec>>;


### PR DESCRIPTION
- Added `tls` and `native_tls` feature flag for `fluvio-socket`.   
- Bump up major version for both `fluvio-socket` and `fluvio-service` due to change in TLS dependency changes