### PR TITLE
Propigate close event when socket closes

### DIFF
--- a/crates/socket/Cargo.toml
+++ b/crates/socket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluvio-socket"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["Fluvio Contributors <team@fluvio.io>"]
 description = "Provide TCP socket wrapper for fluvio protocol"

--- a/crates/socket/src/error.rs
+++ b/crates/socket/src/error.rs
@@ -9,6 +9,9 @@ pub enum FlvSocketError {
         #[from]
         source: IoError,
     },
+    #[error("Socket closed")]
+    SocketClosed,
+
     #[error("Zero-copy IO error")]
     SendFileError {
         #[from]


### PR DESCRIPTION
This will help the rust and node client know when the socket is closed (like internet dropping) for infinyon/fluvio-client-node#43

I spent a bit of time trying to unit test this and found it to be annoying and cumbersome. Thoughts?